### PR TITLE
feat: bearer authorization on swagger ui

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,8 +32,26 @@ export const setupApp = () => {
       swagger({
         documentation: {
           info: { title, version, description },
+          components: {
+            securitySchemes: {
+              bearerAuth: {
+                type: 'http',
+                description: 'Bearer token to access these api endpoints',
+                scheme: 'bearer',
+                bearerFormat: 'JWT',
+              },
+            },
+          },
+          security: [
+            {
+              bearerAuth: [],
+            },
+          ],
         },
         exclude: ['/'],
+        swaggerOptions: {
+          persistAuthorization: true,
+        },
       }),
     )
     .group('/api', (app) => app.use(usersPlugin).use(profilesPlugin));

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import * as jose from 'jose';
 import { env } from '@config';
-import { UserInDb } from '@users/users.schema';
+import type { UserInDb } from '@users/users.schema';
 import { Type } from '@sinclair/typebox';
 import { Value } from '@sinclair/typebox/value';
 import { AuthenticationError } from '@errors';
@@ -69,9 +69,9 @@ export class AuthService {
 
     const tokenParts = rawHeader?.split(' ');
     const tokenType = tokenParts?.[0];
-    if (tokenType !== 'Token')
+    if (tokenType !== 'Bearer')
       throw new AuthenticationError(
-        "Invalid token type. Expected header format: 'Token jwt'",
+        "Invalid token type. Expected header format: 'Bearer jwt'",
       );
 
     const token = tokenParts?.[1];


### PR DESCRIPTION
### Description

While bearer authorization has been implemented, there is no way to utilize this via the Swagger UI in current state.

This MR introduces this value via teh standard jwt mechanism. It also corrects the jwt token prefix to the use standard 'bearer' prefix to align with the jwt standard. Without this change, the bearer token generated fails the 'token' string check.

---

### PR Checklist (Please do not remove)

- [x] Read the [CONTRIBUTING](
  https://github.com/agnyz/the-bed-stack/blob/main/CONTRIBUTING.md) guide
- [x] Title this PR according to the `type(scope): description` or `type: description` format
- [x] Provide description sufficient to understand the changes introduced in this PR, and, if necessary, some screenshots
- [x] Reference an issue or discussion where the feature or changes have been previously discussed
- [x]  ~Add a failing test that passes with the changes introduced in this PR, or explain why it's not feasible~
- [x]  ~Add documentation for the feature or changes introduced in this PR to the docs; you can run them with `bun docs`~
